### PR TITLE
Fix asset resolution for bundling

### DIFF
--- a/lib/tput.js
+++ b/lib/tput.js
@@ -111,21 +111,21 @@ Tput.prototype._useVt102Cap = function() {
 };
 
 Tput.prototype._useXtermCap = function() {
-  return this.injectTermcap(__dirname + '/../usr/xterm.termcap');
+  return this.injectTermcap(require.resolve('../usr/xterm.termcap'));
 };
 
 Tput.prototype._useXtermInfo = function() {
-  return this.injectTerminfo(__dirname + '/../usr/xterm');
+  return this.injectTerminfo(require.resolve('../usr/xterm'));
 };
 
 Tput.prototype._useInternalInfo = function(name) {
   name = path.basename(name);
-  return this.injectTerminfo(__dirname + '/../usr/' + name);
+  return this.injectTerminfo(require.resolve('../usr/' + name));
 };
 
 Tput.prototype._useInternalCap = function(name) {
   name = path.basename(name);
-  return this.injectTermcap(__dirname + '/../usr/' + name + '.termcap');
+  return this.injectTermcap(require.resolve('../usr/' + name + '.termcap'));
 };
 
 /**

--- a/lib/widgets/bigtext.js
+++ b/lib/widgets/bigtext.js
@@ -23,9 +23,9 @@ function BigText(options) {
   }
   options = options || {};
   options.font = options.font
-    || __dirname + '/../../usr/fonts/ter-u14n.json';
-  options.fontBold = options.font
-    || __dirname + '/../../usr/fonts/ter-u14b.json';
+    || require.resolve('../../usr/fonts/ter-u14n.json');
+  options.fontBold = options.fontBold
+    || require.resolve('../../usr/fonts/ter-u14b.json');
   this.fch = options.fch;
   this.ratio = {};
   this.font = this.loadFont(options.font);


### PR DESCRIPTION
## Summary
- improve bundler compatibility by using `require.resolve` for assets
